### PR TITLE
Added ability to set query string parameters for #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ apiBenchmark.measure(service, routes, function(err, results){
 #### data
   (Object): the data sent with the request. In case of function (that has to return an object) it will be evaulated for each request.
 
+#### query
+  (Object): the query sent with the request. In case of function (that has to return an object) it will be evaulated for each request.
+
 #### expectedStatusCode
   (Number, default null): if it is a number, generates an error when the status code of the response is different
 

--- a/lib/request-agent.js
+++ b/lib/request-agent.js
@@ -11,6 +11,7 @@ module.exports = function(agent){
 
   this.make = function(options, callback){
     var data = evalIfFunction(options.data) || {},
+        query = evalIfFunction(options.query) || {},
         headers = evalIfFunction(options.headers) || {},
         method = options.method === 'delete' ? 'del' : options.method,
         request = this.agent[method](options.url);
@@ -18,6 +19,10 @@ module.exports = function(agent){
     if(data !== {}) {
       request.send(data);
 		}
+
+    if(query !== {}) {
+      request.query(data);
+    }
 
     _.forEach(headers, function(header, headerName){
       request.set(headerName, header);

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -51,6 +51,10 @@ module.exports = {
       suiteRequest.data = _.isFunction(suite.endpoint.data) ? 'Dynamic data' : suite.endpoint.data;
 		}
 
+    if(!!suite.endpoint.query){
+      suiteRequest.query = _.isFunction(suite.endpoint.query) ? 'Dynamic query' : suite.endpoint.query;
+    }
+
     suite.runner.add(suiteName, suiteHref, suiteOptions, suiteRequest, function(done){
       self.make(req, suite, suiteName, requestAgent, done);
     });

--- a/templates/report.html
+++ b/templates/report.html
@@ -219,7 +219,8 @@
             template += 'Delay between bench cycles: ' + routeData.options.delay + '<br />';
 
           var requestHeaders = 'none',
-              requestData = 'none';
+              requestData = 'none',
+              requestQuery = 'none';
 
           if(!!routeData.request.headers)
             requestHeaders = '<br /><pre><code>' + JSON.stringify(routeData.request.headers, undefined, 2) + '</pre></code>';
@@ -227,7 +228,10 @@
           if(!!routeData.request.data)
             requestData = '<br /><pre><code>' + JSON.stringify(routeData.request.data, undefined, 2) + '</pre></code>';
 
-          template += '<br />Headers sent: ' + requestHeaders + '<br />Data sent: ' + requestData + '<br /></div><div class="response panel hide">Data here refers to the first sampled response.<br /><br />';
+          if(!!routeData.request.query)
+            requestQuery = '<br /><pre><code>' + JSON.stringify(routeData.request.query, undefined, 2) + '</pre></code>';
+
+          template += '<br />Headers sent: ' + requestHeaders + '<br />Data sent: ' + requestData + '<br />Query sent: ' + requestQuery + '<br /></div><div class="response panel hide">Data here refers to the first sampled response.<br /><br />';
 
           var responseHeader = JSON.stringify(routeData.response.header, undefined, 2),
               responseBody = '';


### PR DESCRIPTION
The ability to set the query string is built into Superagent. We just needed to update the request agent to support passing them to it and add displaying the query in the report.
http://visionmedia.github.io/superagent/#get-requests

@matteofigus What do you think?