### PR TITLE
Fixed responses for request errors in benchmarks

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -8,27 +8,29 @@ module.exports = {
   make: function(req, suite, suiteName, requestAgent, callback){
     requestAgent.make(req, function(err, response){
 
+      var res = !!response ? {
+        header: response.header,
+        statusCode: response.statusCode,
+        body: response.text,
+        type: response.type
+      } : false;
+
       if(err){
         var code = err.code || 'Unknown';
 
         return callback({
           code: code,
           message: err.message || code
-        }, false);
+        }, res);
       }
       else if(!!suite.endpoint.expectedStatusCode && suite.endpoint.expectedStatusCode !== response.status) {
         return callback({
           code: settings.errorCodes.HTTP_STATUS_CODE_NOT_MATCHING,
           message: format(settings.errorMessages.HTTP_STATUS_CODE_NOT_MATCHING, suite.endpoint.expectedStatusCode, response.status, suiteName)
-        }, false);
+        }, res);
 			}
       else {
-				callback(null, {
-					header: response.header,
-					statusCode: response.statusCode,
-					body: response.text,
-					type: response.type
-				});
+				callback(null, res);
 			}
     });
   },

--- a/test/unit/request-handler.js
+++ b/test/unit/request-handler.js
@@ -43,12 +43,12 @@ describe('requestHandler.make function', function(){
 
     var fakeAgent = {
       make: function(req, callback){
-        callback(null, { status: 200 });
+        callback(null, { statusCode: 200 });
       }
     };
 
-    requestHandler.make({}, { endpoint: { expectedStatusCode: 400 }}, 'suiteName', fakeAgent, function(err, success){
-      success.should.be.eql(false);
+    requestHandler.make({}, { endpoint: { expectedStatusCode: 400 }}, 'suiteName', fakeAgent, function(err, res){
+      res.should.be.eql(false);
       err.code.should.be.eql('httpStatusCodeNotMatching');
       done();
     });
@@ -65,8 +65,8 @@ describe('requestHandler.make function', function(){
       }
     };
 
-    requestHandler.make({}, { endpoint: { expectedStatusCode: 400 }}, 'suiteName', fakeAgent, function(err, success){
-      success.should.be.eql(false);
+    requestHandler.make({}, { endpoint: { expectedStatusCode: 400 }}, 'suiteName', fakeAgent, function(err, res){
+      res.should.be.eql(false);
       err.code.should.be.eql('ECONNREFUSED');
       done();
     });

--- a/test/unit/request-handler.js
+++ b/test/unit/request-handler.js
@@ -43,12 +43,22 @@ describe('requestHandler.make function', function(){
 
     var fakeAgent = {
       make: function(req, callback){
-        callback(null, { statusCode: 200 });
+        callback(null, {
+          statusCode: 200,
+          header: '',
+          text: 'hello world',
+          type: 'text/plain'
+        });
       }
     };
 
     requestHandler.make({}, { endpoint: { expectedStatusCode: 400 }}, 'suiteName', fakeAgent, function(err, res){
-      res.should.be.eql(false);
+      res.should.be.eql({
+        statusCode: 200,
+        header: '',
+        body: 'hello world',
+        type: 'text/plain'
+      });
       err.code.should.be.eql('httpStatusCodeNotMatching');
       done();
     });


### PR DESCRIPTION
Played around with this today. This fixes #20 with any error with requests like status code or mean times.

Does this look good @matteofigus?