### PR TITLE
Added returning suites variable when starting benchmark

### DIFF
--- a/lib/api-benchmark.js
+++ b/lib/api-benchmark.js
@@ -17,6 +17,8 @@ var suites = {
           .addServices(parameters.services)
           .onBenchResults(parameters.callback)
           .start();
+
+    return suites;
   }
 };
 


### PR DESCRIPTION
This lets you access the object even when you pass a callback. What I'm now doing is even though I wait for the callback, I'm also listening to the route complete event and sending it to a web socket for a progress bar which is needs to be able to access the `suites` object.