### PR TITLE
Allow the `route` parameter in the route object to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ apiBenchmark.measure(service, routes, function(err, results){
   (String, default 'get'): Http verb.
 
 #### route
-  (String): the route to benchmark
+  (String): the route to benchmark. In case of function (that has to return an string) it will be evaulated for each request.
 
 #### headers
   (Object): the headers to send. In case of function (that has to return an object) it will be evaulated for each request.

--- a/lib/request-agent.js
+++ b/lib/request-agent.js
@@ -16,12 +16,13 @@ module.exports = function(agent){
         route = evalIfFunction(options.route) || '',
         headers = evalIfFunction(options.headers) || {},
         method = options.method === 'delete' ? 'del' : options.method,
-        requestUrl = url.resolve(options.service, route),
+        service = options.service || '',
+        requestUrl = url.resolve(service, route),
         request = this.agent[method](requestUrl);
 
     if(!_.isEmpty(data)) {
       request.send(data);
-		}
+    }
 
     if(!_.isEmpty(query)) {
       request.query(query);

--- a/lib/request-agent.js
+++ b/lib/request-agent.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('underscore');
+var url = require('url');
 
 module.exports = function(agent){
   this.agent = agent;
@@ -12,9 +13,11 @@ module.exports = function(agent){
   this.make = function(options, callback){
     var data = evalIfFunction(options.data) || {},
         query = evalIfFunction(options.query) || {},
+        route = evalIfFunction(options.route) || '',
         headers = evalIfFunction(options.headers) || {},
         method = options.method === 'delete' ? 'del' : options.method,
-        request = this.agent[method](options.url);
+        requestUrl = url.resolve(options.service, route),
+        request = this.agent[method](requestUrl);
 
     if(!_.isEmpty(data)) {
       request.send(data);

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -34,9 +34,9 @@ module.exports = {
 			}
     });
   },
-  setup: function(suiteName, suiteHref, suite, requestAgent){
+  setup: function(suiteName, service, suite, requestAgent){
     var self = this,
-        req = _.extend(_.clone(suite.endpoint), { url: suiteHref }),
+        req = _.extend(_.clone(suite.endpoint), { service: service }),
         suiteOptions = {
           expectedStatusCode: suite.endpoint.expectedStatusCode,
           maxMean: suite.endpoint.maxMean,
@@ -44,6 +44,10 @@ module.exports = {
           method: suite.endpoint.method
         },
         suiteRequest = {};
+
+    if(!!suite.endpoint.route){
+      suiteRequest.route = _.isFunction(suite.endpoint.route) ? 'Dynamic route' : suite.endpoint.route;
+    }
 
     if(!!suite.endpoint.headers){
       suiteRequest.headers = _.isFunction(suite.endpoint.headers) ? 'Dynamic headers' : suite.endpoint.headers;
@@ -57,7 +61,7 @@ module.exports = {
       suiteRequest.query = _.isFunction(suite.endpoint.query) ? 'Dynamic query' : suite.endpoint.query;
     }
 
-    suite.runner.add(suiteName, suiteHref, suiteOptions, suiteRequest, function(done){
+    suite.runner.add(suiteName, suiteRequest.route, suiteOptions, suiteRequest, function(done){
       self.make(req, suite, suiteName, requestAgent, done);
     });
   }

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -46,7 +46,7 @@ module.exports = {
         suiteRequest = {};
 
     if(!!suite.endpoint.route){
-      suiteRequest.route = _.isFunction(suite.endpoint.route) ? 'Dynamic route' : suite.endpoint.route;
+      suiteRequest.route = _.isFunction(suite.endpoint.route) ? 'Dynamic route on ' + service : suite.endpoint.route;
     }
 
     if(!!suite.endpoint.headers){

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -3,6 +3,7 @@
 var format = require('./format');
 var settings = require('./settings');
 var _ = require('underscore');
+var url = require('url');
 
 module.exports = {
   make: function(req, suite, suiteName, requestAgent, callback){
@@ -46,7 +47,7 @@ module.exports = {
         suiteRequest = {};
 
     if(!!suite.endpoint.route){
-      suiteRequest.route = _.isFunction(suite.endpoint.route) ? 'Dynamic route on ' + service : suite.endpoint.route;
+      suiteRequest.route = _.isFunction(suite.endpoint.route) ? 'Dynamic route on ' + service : url.resolve(service, suite.endpoint.route);
     }
 
     if(!!suite.endpoint.headers){

--- a/lib/suites-manager.js
+++ b/lib/suites-manager.js
@@ -7,7 +7,7 @@ var ResultsHandler = require('./results-handler');
 var Runner = require('./runner');
 var sanitise = require('./sanitise');
 var settings = require('./settings');
-var url = require('url');
+
 var validator = require('./validator');
 var _ = require('underscore');
 
@@ -45,11 +45,10 @@ module.exports = function(agent, debugHelper){
       _.forEach(this.services, function(service, serviceName){
         _.forEach(this.routes, function(route){
 
-          var routeHref = url.resolve(service, route.endpoint.route),
-              routeName = serviceName + '/' + route.name,
+          var routeName = serviceName + '/' + route.name,
               self = this;
 
-          requestHandler.setup(routeName, routeHref, route, self.requestAgent);
+          requestHandler.setup(routeName, service, route, self.requestAgent);
         }, this);
       }, this);
 

--- a/test/fixtures/test-agent.js
+++ b/test/fixtures/test-agent.js
@@ -1,20 +1,23 @@
 'use strict';
 
-module.exports.FakeAgent = function(){ 
+module.exports.FakeAgent = function(){
 
   this.end = function(callback){
     callback(null, {
+      url: this.url,
       data: this.data,
       headers: this.headers,
       query: this.queryData
     });
   };
 
-  this.get = function(request){
+  this.get = function(url){
+    this.url = url;
     return this;
   };
 
-  this.post = function(request){
+  this.post = function(url){
+    this.url = url;
     return this;
   };
 

--- a/test/unit/request-agent.js
+++ b/test/unit/request-agent.js
@@ -18,6 +18,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle null data', function(done){
       requestAgent.make({
+        service: 'root',
         route: '/post',
         method: 'post',
         data: null
@@ -29,6 +30,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle undefined data', function(done){
       requestAgent.make({
+        service: 'root',
         route: '/post',
         method: 'post',
         data: undefined
@@ -48,6 +50,7 @@ describe('requestAgent.make function', function(){
     };
 
     var request = {
+      service: 'root',
       route: '/post',
       method: 'post',
       data: dataFunc
@@ -72,6 +75,7 @@ describe('requestAgent.make function', function(){
     };
 
     var request = {
+      service: 'root',
       route: '/get',
       method: 'get',
       query: queryFunc
@@ -88,6 +92,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle cookies', function(done){
       requestAgent.make({
+        service: 'root',
         route: '/get',
         method: 'get',
         headers: {
@@ -101,6 +106,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle headers', function(done){
       requestAgent.make({
+        service: 'root',
         route: '/get',
         method: 'get',
         headers: {
@@ -124,6 +130,7 @@ describe('requestAgent.make function', function(){
     };
 
     var request = {
+      service: 'root',
       route: '/get',
       method: 'get',
       headers: headersFunc

--- a/test/unit/request-agent.js
+++ b/test/unit/request-agent.js
@@ -18,7 +18,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle null data', function(done){
       requestAgent.make({
-        service: 'root',
+        service: 'http://service/',
         route: '/post',
         method: 'post',
         data: null
@@ -30,7 +30,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle undefined data', function(done){
       requestAgent.make({
-        service: 'root',
+        service: 'http://service/',
         route: '/post',
         method: 'post',
         data: undefined
@@ -38,6 +38,30 @@ describe('requestAgent.make function', function(){
         _.isUndefined(fakeResults.data).should.be.eql(true);
         done();
       });
+  });
+
+  it('should correctly handle route as a function', function(done){
+
+    var i = 0;
+
+    var routeFunc = function(){
+      i++;
+      return '/endpoint'+i;
+    };
+
+    var request = {
+      service: 'http://service/',
+      route: routeFunc,
+      method: 'post'
+    };
+
+    requestAgent.make(request, function(err, fakeResults){
+      fakeResults.url.should.be.eql('http://service/endpoint1');
+      requestAgent.make(request, function(err, fakeResults){
+        fakeResults.url.should.be.eql('http://service/endpoint2');
+        done();
+      });
+    });
   });
 
   it('should correctly handle data as a function', function(done){
@@ -50,7 +74,7 @@ describe('requestAgent.make function', function(){
     };
 
     var request = {
-      service: 'root',
+      service: 'http://service/',
       route: '/post',
       method: 'post',
       data: dataFunc
@@ -75,7 +99,7 @@ describe('requestAgent.make function', function(){
     };
 
     var request = {
-      service: 'root',
+      service: 'http://service/',
       route: '/get',
       method: 'get',
       query: queryFunc
@@ -92,7 +116,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle cookies', function(done){
       requestAgent.make({
-        service: 'root',
+        service: 'http://service/',
         route: '/get',
         method: 'get',
         headers: {
@@ -106,7 +130,7 @@ describe('requestAgent.make function', function(){
 
   it('should correctly handle headers', function(done){
       requestAgent.make({
-        service: 'root',
+        service: 'http://service/',
         route: '/get',
         method: 'get',
         headers: {
@@ -130,7 +154,7 @@ describe('requestAgent.make function', function(){
     };
 
     var request = {
-      service: 'root',
+      service: 'http://service/',
       route: '/get',
       method: 'get',
       headers: headersFunc

--- a/test/unit/request-handler.js
+++ b/test/unit/request-handler.js
@@ -37,6 +37,41 @@ describe('requestHandler.setup function', function(){
 
     done();
   });
+
+  it('should properly handle dynamic routes', function(done){
+
+    var fakeAgentStack = [];
+
+    var fakeAgent = {
+      make: function(){
+        fakeAgentStack.push(arguments);
+      }
+    };
+
+    var suiteObj = {
+      endpoint: {
+        aProperty: 'value',
+        route: function () {
+          return 'someDynamicRoute';
+        }
+      },
+      runner: {
+        add: function(suiteName, suiteHref, suiteOptions, suiteRequest, callback){
+          suiteRequest.route.should.be.eql('Dynamic route on serviceRoot');
+          callback();
+        }
+      }
+    };
+
+    requestHandler.setup('suiteName', 'serviceRoot', suiteObj, fakeAgent);
+
+    var req = fakeAgentStack[0][0];
+    req.route.should.be.a.Function();
+    req.service.should.be.eql('serviceRoot');
+    req.aProperty.should.be.eql('value');
+
+    done();
+  });
 });
 
 describe('requestHandler.make function', function(){

--- a/test/unit/request-handler.js
+++ b/test/unit/request-handler.js
@@ -17,7 +17,8 @@ describe('requestHandler.setup function', function(){
 
     var suiteObj = {
       endpoint: {
-        aProperty: 'value'
+        aProperty: 'value',
+        route: 'someRoute'
       },
       runner: {
         add: function(suiteName, suiteHref, suiteOptions, suiteRequest, callback){
@@ -26,11 +27,12 @@ describe('requestHandler.setup function', function(){
       }
     };
 
-    requestHandler.setup('suiteName', 'suiteHref', suiteObj, fakeAgent);
+    requestHandler.setup('suiteName', 'serviceRoot', suiteObj, fakeAgent);
 
     var req = fakeAgentStack[0][0];
 
-    req.url.should.be.eql('suiteHref');
+    req.route.should.be.eql('someRoute');
+    req.service.should.be.eql('serviceRoot');
     req.aProperty.should.be.eql('value');
 
     done();


### PR DESCRIPTION
This PR adds the option to provide a synchronous function as the `route` parameter's value. The function will be executed and the full URL (using the service root) will be resolved before every request.

Please note that when `route` is a function, the `Request` in the `Request details` graph from the report will look like `POST Dynamic route on http://service.url/`.